### PR TITLE
Fix TRAPI 1.5 critical validation errors regarding missing attributes

### DIFF
--- a/src/trapi_predict_kit/trapi_parser.py
+++ b/src/trapi_predict_kit/trapi_parser.py
@@ -275,15 +275,18 @@ def resolve_trapi_query(reasoner_query, endpoints_list, infores: str = ""):
                                         "score": association_score,
                                         # "dummy_score": 0.42,
                                         "scoring_method": "Model confidence between 0 and 1",
-                                        "edge_bindings": {edge_qg_id: [{"id": edge_kg_id}]},
+                                        "edge_bindings": {edge_qg_id: [{"id": edge_kg_id,
+                                                                        "attributes": [],}]},                                        
                                     }
                                 ],
                             }
                             result["node_bindings"][query_plan[edge_id]["qg_subject_node_id"]] = [
-                                {"id": association["subject"]}
+                                {"id": association["subject"],
+                                 "attributes": [],}
                             ]
                             result["node_bindings"][query_plan[edge_id]["qg_object_node_id"]] = [
-                                {"id": association["object"]}
+                                {"id": association["object"],
+                                 "attributes": [],}
                             ]
                             query_results.append(result)
 
@@ -300,6 +303,7 @@ def resolve_trapi_query(reasoner_query, endpoints_list, infores: str = ""):
             node_category = [node_category]
         node_to_add = {
             "categories": node_category,
+            "attributes": []
         }
         if "label" in properties and properties["label"]:
             node_to_add["name"] = properties["label"]


### PR DESCRIPTION
Fix TRAPI 1.5 critical validation errors regarding missing attributes in (KG) nodes and results node bindings and edge bindings

In TRAPI 1.5, attributes are now required and expected to be non-null but can have 0 items. 