### PR TITLE
Filter out health from access log

### DIFF
--- a/src/trapi_predict_kit/trapi.py
+++ b/src/trapi_predict_kit/trapi.py
@@ -1,6 +1,7 @@
 import os
 import time
 from typing import Any, Callable, Dict, List, Optional
+import logging
 
 from fastapi import Body, FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
@@ -317,3 +318,9 @@ def add_opentelemetry(app: FastAPI, service_name: str) -> None:
     # FastAPIInstrumentor.instrument_app(app, tracer_provider=trace, excluded_urls="docs,openapi.json")
     RequestsInstrumentor().instrument()
     HTTPXClientInstrumentor().instrument()
+
+# Filter out /health endpoint to stop flooding uvicorn log 
+class EndpointFilter(logging.Filter):
+    def filter(self, record: logging.LogRecord) -> bool:
+        return record.getMessage().find("/health") == -1
+logging.getLogger("uvicorn.access").addFilter(EndpointFilter())


### PR DESCRIPTION
AWS Cloudwatch logs in ITRB environments are flooded with calls to `/health` endpoint (~10/second). These changes filter out calls to `/health` from the access log. 